### PR TITLE
Trim string when parsing a date

### DIFF
--- a/projects/ngx-mat-datefns-date-adapter/src/lib/ngx-mat-datefns-date-adapter.ts
+++ b/projects/ngx-mat-datefns-date-adapter/src/lib/ngx-mat-datefns-date-adapter.ts
@@ -204,7 +204,7 @@ export class NgxDateFnsDateAdapter extends DateAdapter<Date> {
   parse(value: any, parseFormat: any): Date | null {
     if (value) {
       if (typeof value === 'string') {
-        return parse(value, parseFormat, new Date(), {
+        return parse(value.trim(), parseFormat, new Date(), {
           locale: this._dateFnsLocale,
         });
       }


### PR DESCRIPTION
I noticed that when parsing date strings that come from other sources other than Material Date Picker (for example Saturn Date Picker) that they are sometimes coming with entra whitespaces. So I added a trim function before sending it to date-fns.